### PR TITLE
updates for julia v0.6, drop older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
+
+matrix:
+  allow_failures:
+  - julia: nightly
+
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,36 +1,58 @@
 using Base.Test
 using FixedSizeStrings
 
-let e = FixedSizeString{0}("")
-    @test e == ""
-    @test length(e) == 0
-    @test convert(String, e) == ""
-    @test isa(convert(String, e), String)
-    @test convert(FixedSizeString{0}, "") == e
-end
+@testset "FixedSizeStrings" begin
+    @testset "empty" begin
+        e = FixedSizeString{0}("")
+        @test e == ""
+        @test length(e) == 0
+        @test convert(String, e) == ""
+        @test isa(convert(String, e), String)
+        @test convert(FixedSizeString{0}, "") == e
+    end
 
-@test_throws ErrorException FixedSizeString{3}("ab")
+    @testset "nonempty" begin
+        s = FixedSizeString{3}("xyZ")
+        @test s == "xyZ"
+        @test isless(s, "yyZ")
+        @test isless("xyY", s)
+        @test length(s) == sizeof(s) == 3
+        @test collect(s) == ['x', 'y', 'Z']
+        @test convert(String, s) == "xyZ"
+        @test convert(FixedSizeString{3}, "xyZ") == s
+        @test convert(FixedSizeString{3}, s) == s
+        @test isa(convert(FixedSizeString{3}, "xyZ"), FixedSizeString)
+    end
 
-let s = FixedSizeString{3}("xyZ")
-    @test s == "xyZ"
-    @test isless(s, "yyZ")
-    @test isless("xyY", s)
-    @test length(s) == sizeof(s) == 3
-    @test collect(s) == ['x', 'y', 'Z']
-    @test convert(String, s) == "xyZ"
-    @test convert(FixedSizeString{3}, "xyZ") == s
-    @test isa(convert(FixedSizeString{3}, "xyZ"), FixedSizeString)
-end
+    @testset "constructors" begin
+        @test_throws ErrorException FixedSizeString{3}("ab")
+        @test_throws InexactError FixedSizeString{2}("αb")
+        s = FixedSizeString{2}("de")
+        @test FixedSizeString("de") === s
+        @test FixedSizeString(('d', 'e')) === s
+        @test FixedSizeString{2}((0x64, 0x65)) === s
+        @test FixedSizeString((0x64, 0x65)) === s
+        @test FixedSizeString([0x64, 0x65]) === s
+        @test FixedSizeString([100, 101]) === s
+    end
 
-@test_throws InexactError FixedSizeString{2}("αb")
+    @testset "index & iterate" begin
+        s = FixedSizeString{3}("%#!")
+        @test endof(s) === 3
+        @test next(s, 2) === ('#', 3)
+        @test s[3] === '!'
+        @test sizeof(s) === 3
+    end
 
-let b = IOBuffer()
-    write(b, "a tEst str1ng")
-    seekstart(b)
-    @test read(b, FixedSizeString{4}) == "a tE"
-    @test read(b, FixedSizeString{2}) == "st"
-    b = IOBuffer()
-    data = "\0Te\$t\0_"
-    write(b, FixedSizeString(data))
-    @test takebuf_string(b) == data
+    @testset "read & write" begin
+        b = IOBuffer()
+        write(b, "a tEst str1ng")
+        seekstart(b)
+        @test read(b, FixedSizeString{4}) == "a tE"
+        @test read(b, FixedSizeString{2}) == "st"
+        b = IOBuffer()
+        data = "\0Te\$t\0_"
+        write(b, FixedSizeString(data))
+        @test String(take!(b)) == data
+    end
 end


### PR DESCRIPTION
- drop support for pre julia v0.6
- moved out inner constructors without type parameter to functions, since this was deprecated
- added tests for the different constructors
- added tests on iterating and indexing
- start using testsets
- update syntax (struct / where)
- test on julia v0.6, nightly set to allowed failure (currently doesn't work)