### PR TITLE
Add parameter to string to support U16 and U32

### DIFF
--- a/src/FixedSizeStrings.jl
+++ b/src/FixedSizeStrings.jl
@@ -1,41 +1,48 @@
 module FixedSizeStrings
 
-export FixedSizeString
+export FixedSizeString, FixedSizeString16, FixedSizeString32
 
 import Base: iterate, lastindex, getindex, sizeof, length, ncodeunits, codeunit, isvalid, read, write
 
-struct FixedSizeString{N} <: AbstractString
-    data::NTuple{N,UInt8}
-    FixedSizeString{N}(itr) where {N} = new(NTuple{N,UInt8}(itr))
+struct FixedSizeStringGeneric{N,T} <: AbstractString
+    data::NTuple{N,T}
+    FixedSizeStringGeneric{N,T}(itr) where {N,T} = new(NTuple{N,T}(itr))
 end
 
-FixedSizeString(s::AbstractString) = FixedSizeString{length(s)}(s)
+const FixedSizeString{N} = FixedSizeStringGeneric{N,UInt8} where N
+const FixedSizeString16{N} = FixedSizeStringGeneric{N,UInt16} where N
+const FixedSizeString32{N} = FixedSizeStringGeneric{N,UInt32} where N
 
-function iterate(s::FixedSizeString{N}, i::Int = 1) where N
+FixedSizeString(s::AbstractString) = FixedSizeString{length(s)}(s)
+FixedSizeString16(s::AbstractString) = FixedSizeString16{length(s)}(s)
+FixedSizeString32(s::AbstractString) = FixedSizeString32{length(s)}(s)
+
+function iterate(s::FixedSizeStringGeneric{N}, i::Int = 1) where N
     i > N && return nothing
     return (Char(s.data[i]), i+1)
 end
 
-lastindex(s::FixedSizeString{N}) where {N} = N
+lastindex(s::FixedSizeStringGeneric{N}) where {N} = N
 
-getindex(s::FixedSizeString, i::Int) = Char(s.data[i])
+getindex(s::FixedSizeStringGeneric, i::Int) = Char(s.data[i])
 
-sizeof(s::FixedSizeString) = sizeof(s.data)
+sizeof(s::FixedSizeStringGeneric) = sizeof(s.data)
 
-length(s::FixedSizeString) = length(s.data)
+length(s::FixedSizeStringGeneric) = length(s.data)
 
-ncodeunits(s::FixedSizeString) = length(s.data)
+ncodeunits(s::FixedSizeStringGeneric) = length(s.data)
 
-codeunit(::FixedSizeString) = UInt8
-codeunit(s::FixedSizeString, i::Integer) = s.data[i]
+codeunit(::FixedSizeStringGeneric{<:Any,T}) where T = T
+codeunit(s::FixedSizeStringGeneric, i::Integer) = s.data[i]
 
 isvalid(s::FixedSizeString, i::Int) = checkbounds(Bool, s, i)
+isvalid(s::FixedSizeStringGeneric, i::Int) = checkbounds(Bool, s, i) && isvalid(Char,s.data[i])
 
-function read(io::IO, T::Type{FixedSizeString{N}}) where N
+function read(io::IO, T::Type{<:FixedSizeStringGeneric{N}}) where N
     return read!(io, Ref{T}())[]::T
 end
 
-function write(io::IO, s::FixedSizeString{N}) where N
+function write(io::IO, s::FixedSizeStringGeneric{N}) where N
     return write(io, Ref(s))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,3 +34,35 @@ let b = IOBuffer()
     write(b, FixedSizeString(data))
     @test String(take!(b)) == data
 end
+
+let e = FixedSizeString16{0}("")
+    @test e == ""
+    @test length(e) == 0
+    @test convert(String, e) === ""
+    @test isa(convert(String, e), String)
+    @test convert(FixedSizeString16{0}, "") == e
+end
+
+@test_throws ArgumentError FixedSizeString16{3}("ab")
+
+let s = FixedSizeString16{3}("xYβ")
+    @test s == "xYβ"
+    @test isless(s, "yYβ")
+    @test isless("xYα", s)
+    @test 2*length(s) == sizeof(s) == 6
+    @test collect(s) == ['x', 'Y', 'β']
+    @test convert(String, s) == "xYβ"
+    @test convert(FixedSizeString16{3}, "xYβ") == s
+    @test isa(convert(FixedSizeString16{3}, "xYβ"), FixedSizeString16)
+end
+
+let b = IOBuffer()
+    write(b, FixedSizeString32("a tEσt str1ng"))
+    seekstart(b)
+    @test read(b, FixedSizeString32{4}) == "a tE"
+    @test read(b, FixedSizeString32{2}) == "σt"
+    b = IOBuffer()
+    data = "\0𝚯ϵ\$t\0_"
+    write(b, FixedSizeString32(data))
+    @test String(Char.(reinterpret(UInt32,take!(b)))) == data
+end


### PR DESCRIPTION
This extension would be needed to parse fixed-size encoded strings in the Zarr data format. I tried to implement this in a way to be backwards-compatible, which is why I changed the type name and added the alias. 